### PR TITLE
Fix DOM query selector filtering

### DIFF
--- a/content.js
+++ b/content.js
@@ -35,7 +35,8 @@ function extractCourseData() {
     const courses = [];
     
     // First try the specialized approach for the common format we're seeing
-    const courseElements = document.querySelectorAll('div, section, article').filter(el => {
+    // querySelectorAll returns a NodeList, convert to an array before using array methods
+    const courseElements = Array.from(document.querySelectorAll('div, section, article')).filter(el => {
       // Look for headings or elements that likely contain course names
       const heading = el.querySelector('h1, h2, h3, h4, h5, strong');
       if (!heading) return false;


### PR DESCRIPTION
## Summary
- convert querySelectorAll result to an array before filtering to avoid runtime errors in content script

## Testing
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_68951770fdd48329a98c0e9d481fdd12