### PR TITLE
fix: include extractor scripts as web resources

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,12 @@
       "js": ["courseDataExtractor.js", "content.js"]
     }
   ],
+  "web_accessible_resources": [
+    {
+      "resources": ["courseDataExtractor.js", "content.js"],
+      "matches": ["https://mumaaenroll.services.wisc.edu/*"]
+    }
+  ],
   "background": {
     "service_worker": "background.js"
   },


### PR DESCRIPTION
## Summary
- expose `courseDataExtractor.js` and `content.js` via `web_accessible_resources` so the popup can inject them reliably

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966131f0f08329be502f8582bcf081