### PR TITLE
Align data preparation with source trading calendar

### DIFF
--- a/stock_direction_trader.py
+++ b/stock_direction_trader.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+
+def prepare_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Prepare stock data without imposing a generic business day calendar.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Raw price data with a DateTimeIndex as provided by the data source
+        (e.g., yfinance).
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with additional features computed using the original
+        DateTimeIndex from the source. No reindexing is performed.
+    """
+    # Work on a copy to avoid mutating caller's DataFrame
+    data = df.copy()
+
+    # Example feature: daily returns
+    if 'Close' in data.columns:
+        data['Return'] = data['Close'].pct_change()
+
+    # Drop initial NA from pct_change or any missing values
+    data.dropna(inplace=True)
+
+    return data

--- a/tests/test_calendar_alignment.py
+++ b/tests/test_calendar_alignment.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pandas as pd
+import yfinance as yf
+
+# Ensure the project root is on the path for module imports
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from stock_direction_trader import prepare_data
+
+
+def test_calendar_alignment():
+    # Fetch data including a known holiday period to ensure gaps exist
+    df = yf.download('AAPL', start='2023-12-20', end='2024-01-10', progress=False)
+    prepared = prepare_data(df)
+
+    fetched_idx = df.index
+    prepared_idx = prepared.index
+
+    # Intersection length should equal prepared index length
+    assert len(prepared_idx.intersection(fetched_idx)) == len(prepared_idx)


### PR DESCRIPTION
## Summary
- Preserve DateTimeIndex from source data in `prepare_data`
- Add test ensuring prepared data aligns with fetched trading days

## Testing
- `pytest tests/test_calendar_alignment.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689cf295685c83299bab874757f91f47